### PR TITLE
Created the GraphQL type definitions

### DIFF
--- a/server/schemas/typeDef.js
+++ b/server/schemas/typeDef.js
@@ -1,0 +1,49 @@
+const { gql } = require("apollo-server-express");
+
+const typeDefs = gql`
+  type User {
+    _id: ID
+    username: String
+    email: String
+    bookCount: Int
+    savedBooks: [Book]
+  }
+
+  type Book {
+    _id: ID
+    bookId: String
+    authors: [String]!
+    description: String
+    title: String
+    image: String
+    link: String
+  }
+
+  type Auth {
+    token: ID!
+    user: User
+  }
+
+  input SaveBookInput {
+    authors: [String]!
+    description: String
+    title: String
+    bookId: String
+    image: String
+    link: String
+  }
+
+  type Query {
+    me: User
+  }
+
+  type Mutation {
+    login(email: String!, password: String!): Auth
+    addUser(username: String!, email: String!, password: String!): Auth
+
+    saveBook(input: SaveBookInput!): User
+    removeBook(bookId: String!): User
+  }
+`;
+
+module.exports = typeDefs;


### PR DESCRIPTION
- Added the GraphQL type definitions for User, Book, Auth, SaveBookInput, Query, and Mutation.
- User type includes fields for _id, username, email, bookCount, and savedBooks.
- Book type includes fields for _id, bookId, authors, description, title, image, and link.
- Auth type includes fields for token and user.
- SaveBookInput input type includes fields for authors, description, title, bookId, image, and link.